### PR TITLE
Bugfix for fatal errors processing zoneinfo directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM armhf/ubuntu:xenial
+FROM arm32v7/ubuntu:xenial
 
 MAINTAINER James Bacon james@baconi.co.uk
 

--- a/install-mysql.bash
+++ b/install-mysql.bash
@@ -11,7 +11,7 @@ debconf-set-selections <<< "mysql-server mysql-server/root_password_again passwo
 apt-get update
 
 ## Install MySQL
-apt-get install -y mysql-server-${MYSQL_MAJOR}
+apt-get install -y mysql-server-${MYSQL_MAJOR} tzdata
 
 ## Clean up any mess
 apt-get clean autoclean


### PR DESCRIPTION
This change should fix issue #1 
- Updated to use the latest official arm image **arm32v7** instead of **armhf**.
- Installs the now missing tzdata package from the base image.