### PR TITLE
working with all current os archs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/ubuntu:xenial
+FROM ubuntu:xenial
 
 MAINTAINER James Bacon james@baconi.co.uk
 


### PR DESCRIPTION
Hey,

This minor change on your Dockerfile make your project to work with all current os architectures.
The change is basically this:

`FROM arm32v7/ubuntu:xenial`

`FROM ubuntu:xenial`

All Ubuntu current versions have been updated to work with a lot of others architectures.

I already tested this, and works flawlessly on AWS Graviton2 instances.